### PR TITLE
Add Support for CDM API Token Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Types of changes
+
+* **Added** for new features.
+* **Changed** for changes in existing functionality.
+* **Deprecated** for soon-to-be removed features.
+* **Removed** for now removed features.
+* **Fixed** for any bug fixes.
+* **Security** in case of vulnerabilities.
+
+## Unreleased
+
+### Added
+
+* Added the ability to authenticate against a CDM cluster using an API Token. [Issue 17](https://github.com/rubrikinc/graphql-playground/issues/17) 

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ class App extends Component {
       nodeIp: null,
       username: null,
       password: null,
+      cdmApiToken: null,
       apiToken: null,
       polarisDomain: null,
     };

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -31,13 +31,15 @@ class LandingPage extends Component {
       ip: null,
       username: null,
       password: null,
+      cdmApiToken: null,
       polarisDomain: polarisUserDomain,
+      usingCdmApiToken: false,
     };
 
     this.createLoginForm = this.createLoginForm.bind(this);
     this.handleSwitchToLogin = this.handleSwitchToLogin.bind(this);
     this.handleSelectYourPlatform = this.handleSelectYourPlatform.bind(this);
-    this.onChange = this.onChange.bind(this);
+    this.onFormChange = this.onFormChange.bind(this);
     this.handleLoginButton = this.handleLoginButton.bind(this);
     this.createLoginHeader = this.createLoginHeader.bind(this);
     this.createDevModeIcon = this.createDevModeIcon.bind(this);
@@ -66,13 +68,24 @@ class LandingPage extends Component {
         this.state.ip,
         this.state.username,
         this.state.password,
+        this.state.cdmApiToken,
+        this.state.usingCdmApiToken,
         this.state.polarisDomain
       );
 
       this.setState({
-        apiToken: apiToken,
+        apiToken: this.state.cdmApiToken ? this.state.cdmApiToken : apiToken,
         loginButtonText: "Login",
       });
+
+      // If using API Token Authentication for CDM connectivity, reset the username
+      // and password to null in case they were also filled out in the login form
+      if (this.state.usingCdmApiToken) {
+        this.setState({
+          username: null,
+          password: null,
+        });
+      }
 
       this.props.credentialUpdate(
         this.state.platform,
@@ -84,7 +97,10 @@ class LandingPage extends Component {
       );
     } catch (error) {
       this.setState({
-        loginErrorMessage: userFiendlyErrorMessage(error),
+        loginErrorMessage: userFiendlyErrorMessage(
+          error,
+          this.state.usingCdmApiToken
+        ),
         loginButtonText: loginButtonText,
       });
     }
@@ -94,6 +110,7 @@ class LandingPage extends Component {
     this.setState({
       platform: this.state.platform === "polaris" ? "cdm" : "polaris",
       loginErrorMessage: null,
+      usingCdmApiToken: false,
     });
   }
 
@@ -106,10 +123,17 @@ class LandingPage extends Component {
     });
   }
 
-  onChange(event) {
+  onFormChange(event) {
     // This function handles the input from the form fields and sets the
     // appropriate state.
-    this.setState({ [event.target.id]: event.target.value });
+
+    if (event.target.id !== "useApiTokenCheckBox") {
+      this.setState({ [event.target.id]: event.target.value });
+    } else {
+      this.setState({
+        usingCdmApiToken: event.target.checked,
+      });
+    }
   }
 
   createFullLandingPageUi() {
@@ -276,8 +300,10 @@ class LandingPage extends Component {
         ip={this.state.ip}
         username={this.state.username}
         password={this.state.password}
+        cdmApiToken={this.state.cdmApiToken}
+        usingCdmApiToken={this.state.usingCdmApiToken}
         selectYourPlatform={this.handleSelectYourPlatform}
-        onChange={this.onChange}
+        onFormChange={this.onFormChange}
         loginButton={this.handleLoginButton}
         loginButtonText={this.state.loginButtonText}
         polarisDomain={this.state.polarisDomain}

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -2,6 +2,8 @@ import React from "react";
 import TextField from "@material-ui/core/TextField";
 import { makeStyles } from "@material-ui/core/styles";
 import { Button } from "@material-ui/core";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
 
 import InputAdornment from "@material-ui/core/InputAdornment";
 import "../components/LandingPage.css";
@@ -63,33 +65,54 @@ export default function LoginForm(props) {
   function diableLoginButton() {
     // This function controls whether or not the field button is disabled.
     // The logic is super ugly and can be cleaned up but it works
-    if (
-      props.ip === null ||
-      props.username === null ||
-      props.password === null
-    ) {
-      return true;
-    }
-    if (props.ip !== null) {
-      if (props.ip.length <= 0) {
+    if (props.usingCdmApiToken === false) {
+      if (
+        props.ip === null ||
+        props.username === null ||
+        props.password === null
+      ) {
         return true;
       }
-    }
+      if (props.ip !== null) {
+        if (props.ip.length <= 0) {
+          return true;
+        }
+      }
 
-    if (props.username !== null) {
-      if (props.username.length <= 0) {
+      if (props.username !== null) {
+        if (props.username.length <= 0) {
+          return true;
+        }
+      }
+
+      if (props.password !== null) {
+        if (props.password.length <= 0) {
+          return true;
+        }
+      }
+
+      if (props.loginButtonText !== "Login") {
         return true;
       }
-    }
-
-    if (props.password !== null) {
-      if (props.password.length <= 0) {
+    } else {
+      if (props.ip === null || props.cdmApiToken === null) {
         return true;
       }
-    }
+      if (props.ip !== null) {
+        if (props.ip.length <= 0) {
+          return true;
+        }
+      }
 
-    if (props.loginButtonText !== "Login") {
-      return true;
+      if (props.cdmApiToken !== null) {
+        if (props.cdmApiToken.length <= 0) {
+          return true;
+        }
+      }
+
+      if (props.loginButtonText !== "Login") {
+        return true;
+      }
     }
   }
 
@@ -106,7 +129,7 @@ export default function LoginForm(props) {
           required
           id="ip"
           label={props.platform === "cdm" ? "CDM IP or FQDN" : "Polaris Domain"}
-          onChange={props.onChange}
+          onChange={props.onFormChange}
           InputProps={
             props.platform === "cdm"
               ? null
@@ -119,21 +142,59 @@ export default function LoginForm(props) {
                 }
           }
         />
+
         <TextField
-          required
-          id="username"
-          label="Username"
-          onChange={props.onChange}
-          error={props.username !== null && props.username === ""}
+          required={props.usingCdmApiToken === true ? true : false}
+          id="cdmApiToken"
+          label="API Token"
+          type="password"
+          onChange={props.onFormChange}
+          error={props.cdmApiToken !== null && props.cdmApiToken === ""}
+          style={props.usingCdmApiToken === false ? { display: "none" } : {}}
         />
 
         <TextField
-          required
+          required={props.usingCdmApiToken === false ? true : false}
+          id="username"
+          label="Username"
+          onChange={props.onFormChange}
+          error={props.username !== null && props.username === ""}
+          style={props.usingCdmApiToken === true ? { display: "none" } : {}}
+        />
+
+        <TextField
+          required={props.usingCdmApiToken === false ? true : false}
           id="password"
           label="Password"
           type="password"
-          onChange={props.onChange}
+          onChange={props.onFormChange}
           error={props.password !== null && props.password === ""}
+          style={props.usingCdmApiToken === true ? { display: "none" } : {}}
+        />
+        {/* TODO: Enable Remember Me functionality */}
+        {/* <FormControlLabel
+          control={
+            <Checkbox
+              checked={state.rememberMe}
+              onChange={handleCheckBox}
+              name="rememberMe"
+              color="primary"
+            />
+          }
+          label="Remember me"
+        /> */}
+        <FormControlLabel
+          control={
+            <Checkbox
+              id="useApiTokenCheckBox"
+              checked={props.usingCdmApiToken}
+              onChange={props.onFormChange}
+              name="usingCdmApiToken"
+              color="primary"
+            />
+          }
+          style={props.platform === "polaris" ? { display: "none" } : {}}
+          label="Use API Token Authentication"
         />
       </div>
       <div className={classesLoginButton.root}>


### PR DESCRIPTION
# Description

Add the ability to login using a CDM Authentication token
## Related Issue

<!-- Please link to the issue here-->

https://github.com/rubrikinc/graphql-playground/issues/17

## Motivation and Context

The Support organization requested this enhancement as they regularly use API Tokens instead of username and password.

## How Has This Been Tested?

- Manual integration tests

## Screenshots (if appropriate):

![Screen Shot 2020-05-09 at 9 01 10 PM](https://user-images.githubusercontent.com/8610203/81489197-837c3280-9238-11ea-9e9a-d0fe9f206a2a.png)


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)