### PR TITLE
Specify custom Polaris development domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * **Fixed** for any bug fixes.
 * **Security** in case of vulnerabilities.
 
+## Unreleased
+
+### Added
+
+* Specify custom Polaris development domains. [Issue 23](https://github.com/rubrikinc/graphql-playground/issues/23) 
+
 ## v2.0.1
 
 ### Added

--- a/src/components/defaultSettings/DefaultPlatformSelection.js
+++ b/src/components/defaultSettings/DefaultPlatformSelection.js
@@ -15,7 +15,7 @@ import DesktopMacIcon from "@material-ui/icons/DesktopMac";
 // Used to format the Select dropdown
 const useStyles = makeStyles(() => ({
   formControl: {
-    minWidth: 100,
+    minWidth: 150,
     marginRight: 20,
   },
 }));

--- a/src/components/defaultSettings/PolarisDevelopmentDevDomain.js
+++ b/src/components/defaultSettings/PolarisDevelopmentDevDomain.js
@@ -1,0 +1,50 @@
+import React from "react";
+
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import LanguageIcon from "@material-ui/icons/Language";
+import TextField from "@material-ui/core/TextField";
+
+const storage = window.localStorage;
+
+const convertStringToBoolean = (string) => {
+  let bool;
+  string === "false" ? (bool = false) : (bool = true);
+  return bool;
+};
+
+const PolarisDevelopmentDevDomain = ({ handlePolarisDevModeState }) => {
+  const [devDomain, setDevDomain] = React.useState(
+    storage.getItem("polarisDevDomain") === null
+      ? "dev"
+      : convertStringToBoolean(storage.getItem("polarisDevDomain"))
+  );
+
+  const handleChange = (event) => {
+    setDevDomain(event.target.checked);
+
+    handlePolarisDevModeState(event.target.checked);
+  };
+
+  return (
+    <List>
+      <ListItem>
+        <ListItemIcon>
+          <LanguageIcon />
+        </ListItemIcon>
+        <ListItemText
+          id="polaris-development-domain"
+          primary="Polaris Development Domain"
+        />
+        <ListItemSecondaryAction>
+          <TextField id="standard-basic" defaultValue={devDomain} />
+        </ListItemSecondaryAction>
+      </ListItem>
+    </List>
+  );
+};
+
+export default PolarisDevelopmentDevDomain;

--- a/src/components/defaultSettings/PolarisDevelopmentDevDomain.js
+++ b/src/components/defaultSettings/PolarisDevelopmentDevDomain.js
@@ -10,23 +10,16 @@ import TextField from "@material-ui/core/TextField";
 
 const storage = window.localStorage;
 
-const convertStringToBoolean = (string) => {
-  let bool;
-  string === "false" ? (bool = false) : (bool = true);
-  return bool;
-};
-
-const PolarisDevelopmentDevDomain = ({ handlePolarisDevModeState }) => {
+const PolarisDevelopmentDevDomain = ({ handlePolarisDevDomain }) => {
   const [devDomain, setDevDomain] = React.useState(
     storage.getItem("polarisDevDomain") === null
       ? "dev"
-      : convertStringToBoolean(storage.getItem("polarisDevDomain"))
+      : storage.getItem("polarisDevDomain")
   );
 
   const handleChange = (event) => {
-    setDevDomain(event.target.checked);
-
-    handlePolarisDevModeState(event.target.checked);
+    setDevDomain(event.target.value);
+    handlePolarisDevDomain(event.target.value);
   };
 
   return (
@@ -40,7 +33,11 @@ const PolarisDevelopmentDevDomain = ({ handlePolarisDevModeState }) => {
           primary="Polaris Development Domain"
         />
         <ListItemSecondaryAction>
-          <TextField id="standard-basic" defaultValue={devDomain} />
+          <TextField
+            id="standard-basic"
+            defaultValue={devDomain}
+            onChange={handleChange}
+          />
         </ListItemSecondaryAction>
       </ListItem>
     </List>

--- a/src/components/defaultSettings/SettingsDialog.js
+++ b/src/components/defaultSettings/SettingsDialog.js
@@ -17,6 +17,7 @@ import MuiDialogActions from "@material-ui/core/DialogActions";
 import CdmApiTokenToggle from "./CdmApiTokenToggle";
 import PolarisDevelopmentModeToggle from "./PolarisDevelopmentModeToggle";
 import DefaultPlatformSelection from "./DefaultPlatformSelection";
+import PolarisDevelopmentDevDomain from "./PolarisDevelopmentDevDomain";
 
 import { createMuiTheme } from "@material-ui/core/styles";
 import { ThemeProvider } from "@material-ui/styles";
@@ -87,6 +88,7 @@ export default function SettingsDialog(props) {
   const [cdmApiToken, setCdmApiTokenState] = React.useState(false);
   const [polarisDevMode, setPolarisDevModeState] = React.useState(false);
   const [defaultPlatform, setDefaultPlatform] = React.useState("none");
+  const [defaultDevDomain, setDefaultDevDomain] = React.useState("dev");
 
   const handleSettingsOpen = () => {
     setSettingsOpen(true);
@@ -102,8 +104,14 @@ export default function SettingsDialog(props) {
     storage.setItem("platform", defaultPlatform);
     storage.setItem("cdmApiToken", cdmApiToken);
     storage.setItem("polarisDevMode", polarisDevMode);
+    storage.setItem("polarisDevDomain", defaultDevDomain);
 
-    props.handleDefaultUpdate(defaultPlatform, cdmApiToken, polarisDevMode);
+    props.handleDefaultUpdate(
+      defaultPlatform,
+      cdmApiToken,
+      polarisDevMode,
+      defaultDevDomain
+    );
     setSettingsOpen(false);
   };
 
@@ -128,6 +136,10 @@ export default function SettingsDialog(props) {
 
   const handleDefaultPlatform = (platform) => {
     setDefaultPlatform(platform);
+  };
+
+  const handlePolarisDevDomain = (domain) => {
+    setDefaultDevDomain(domain);
   };
 
   const settingsDialog = () => {
@@ -160,6 +172,9 @@ export default function SettingsDialog(props) {
                 />
                 <PolarisDevelopmentModeToggle
                   handlePolarisDevModeState={handlePolarisDevModeState}
+                />
+                <PolarisDevelopmentDevDomain
+                  handlePolarisDevDomain={handlePolarisDevDomain}
                 />
               </DialogContent>
             </ThemeProvider>

--- a/src/components/defaultSettings/SettingsDialog.js
+++ b/src/components/defaultSettings/SettingsDialog.js
@@ -105,7 +105,6 @@ export default function SettingsDialog(props) {
     storage.setItem("cdmApiToken", cdmApiToken);
     storage.setItem("polarisDevMode", polarisDevMode);
     storage.setItem("polarisDevDomain", defaultDevDomain);
-
     props.handleDefaultUpdate(
       defaultPlatform,
       cdmApiToken,

--- a/src/components/landingPage/LandingPage.js
+++ b/src/components/landingPage/LandingPage.js
@@ -22,8 +22,6 @@ const selectYourPlatformFormHeader = "Select your Platform";
 const loginButtonText = "Login";
 const connectingToPlatformButtonText = "Attempting to Connect";
 const polarisUserDomain = ".my.rubrik.com";
-const polarisDevDomain = ".dev.my.rubrik-lab.com";
-
 const storage = window.localStorage;
 
 const convertStringToBoolean = (string) => {
@@ -50,6 +48,10 @@ class LandingPage extends Component {
       password: null,
       cdmApiToken: null,
       polarisDomain: polarisUserDomain,
+      polarisDevDomain:
+        storage.getItem("polarisDevDomain") === null
+          ? ".dev.my.rubrik-lab.com"
+          : `.${storage.getItem("polarisDevDomain")}.my.rubrik-lab.com`,
       usingCdmApiToken:
         storage.getItem("cdmApiToken") === null
           ? false
@@ -80,7 +82,7 @@ class LandingPage extends Component {
 
     if (storage.getItem("polarisDevMode") === "true") {
       this.setState({
-        polarisDomain: polarisDevDomain,
+        polarisDomain: this.state.polarisDevDomain,
       });
     }
   }
@@ -153,7 +155,7 @@ class LandingPage extends Component {
     });
   }
 
-  handleDefaultUpdate(platform, cdmApiToken, polarisDevMode) {
+  handleDefaultUpdate(platform, cdmApiToken, polarisDevMode, polarisDevDomain) {
     if (this.state.platform !== platform) {
       this.setState({
         platform: platform === "none" ? null : platform,
@@ -168,15 +170,33 @@ class LandingPage extends Component {
 
     this.setState({
       polarisDomain:
-        polarisDevMode === true ? polarisDevDomain : polarisUserDomain,
+        polarisDevMode === true
+          ? this.state.polarisDevDomain
+          : polarisUserDomain,
     });
+
+    this.setState({
+      polarisDomain:
+        this.state.polarisDomain === polarisUserDomain
+          ? this.state.polarisDevDomain
+          : polarisUserDomain,
+    });
+
+    if (
+      this.state.polarisDevDomain !== `.${polarisDevDomain}.my.rubrik-lab.com`
+    ) {
+      this.setState({
+        polarisDomain: `.${polarisDevDomain}.my.rubrik-lab.com`,
+        polarisDevDomain: `.${polarisDevDomain}.my.rubrik-lab.com`,
+      });
+    }
   }
 
   handleModeButton() {
     this.setState({
       polarisDomain:
         this.state.polarisDomain === polarisUserDomain
-          ? polarisDevDomain
+          ? this.state.polarisDevDomain
           : polarisUserDomain,
     });
   }


### PR DESCRIPTION
# Description

- Add the ability to specify a development domain other than "dev" in the Default Settings dialog

## Related Issue

https://github.com/rubrikinc/graphql-playground/issues/23

## How Has This Been Tested?

- Manual integration tests


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
